### PR TITLE
Clearer error message if :ueberauth configs are missing

### DIFF
--- a/lib/ueberauth/strategy/auth0/oauth.ex
+++ b/lib/ueberauth/strategy/auth0/oauth.ex
@@ -19,6 +19,7 @@ defmodule Ueberauth.Strategy.Auth0.OAuth do
 
   def options(otp_app) do
     configs = Application.get_env(otp_app || :ueberauth, Ueberauth.Strategy.Auth0.OAuth)
+      || raise("Expected to find env settings at Ueberauth.Strategy.Auth0.OAuth, got nil. Check your config.exs.")
 
     domain = get_config_value(configs[:domain])
     client_id = get_config_value(configs[:client_id])


### PR DESCRIPTION
Yesterday when setting up Auth0 integration I got the following error message:

```
Request: GET /auth/login
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Keyword.merge/2
        (elixir) lib/keyword.ex:707: Keyword.merge(nil, [strategy: Ueberauth.Strategy.Auth0.OAuth, site: "https://", authorize_url: "https:///authorize", token_url: "https:///oauth/token", userinfo_url: "https:///userinfo", client_id: nil, client_secret: nil])
        (ueberauth_auth0) lib/ueberauth/strategy/auth0/oauth.ex:47: Ueberauth.Strategy.Auth0.OAuth.client/1
        (ueberauth_auth0) lib/ueberauth/strategy/auth0/oauth.ex:57: Ueberauth.Strategy.Auth0.OAuth.authorize_url!/2
        (ueberauth_auth0) lib/ueberauth/strategy/auth0.ex:38: Ueberauth.Strategy.Auth0.handle_request!/1
        (rtl) lib/rtl_web/controllers/auth_controller.ex:1: RTLWeb.AuthController.phoenix_controller_pipeline/2
        (rtl) lib/rtl_web/endpoint.ex:1: RTLWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/router.ex:275: Phoenix.Router.__call__/1
        ...
```

I needed to do a bit of digging to understand this. It looks like `Ueberauth.Strategy.Auth0.OAuth.options()` tries to fetch the Application env and got nil because I had a typo in my `config.exs`. Then it blew up when calling `Keyword.merge(nil, opts)`, but the stacktrace doesn't make it easy to recognize that this was a config error on my part rather than a bug in the dependency. I'd like ueberauth_auth0 to give me more concrete feedback if this happens.

This PR adds an explicit check for the expected env. If it isn't found, users will get an easier-to-understand exception which makes it clear that an expected config setting was missing, and hints that you might have misconfigured your project:

```
Request: GET /auth/login
** (exit) an exception was raised:
    ** (RuntimeError) Expected to find configured settings at Ueberauth.Strategy.Auth0.OAuth, got nil. Check your config.exs.
        (ueberauth_auth0) lib/ueberauth/strategy/auth0/oauth.ex:22: Ueberauth.Strategy.Auth0.OAuth.options/0
        (ueberauth_auth0) lib/ueberauth/strategy/auth0/oauth.ex:48: Ueberauth.Strategy.Auth0.OAuth.client/1
        (ueberauth_auth0) lib/ueberauth/strategy/auth0/oauth.ex:58: Ueberauth.Strategy.Auth0.OAuth.authorize_url!/2
        (ueberauth_auth0) lib/ueberauth/strategy/auth0.ex:38: Ueberauth.Strategy.Auth0.handle_request!/1
        (rtl) lib/rtl_web/controllers/auth_controller.ex:1: RTLWeb.AuthController.phoenix_controller_pipeline/2
        (rtl) lib/rtl_web/endpoint.ex:1: RTLWeb.Endpoint.instrument/4
        (phoenix) lib/phoenix/router.ex:275: Phoenix.Router.__call__/1
```

Notes:

- I'd welcome any less terrible wording for the exception.
- I was unable to get `mix dialyzer` to pass as per the [contributing guide](https://github.com/sntran/ueberauth_auth0/blob/master/CONTRIBUTING.md). I got an error "module Erlex is not available" which I don't have bandwidth to troubleshoot atm.