### PR TITLE
Add per-app config info to readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.4.0
+
+- Added support for per-app config.
+
 ## Version 0.3.0
 
 Thanks @sobolevn for updating the followings:

--- a/README.md
+++ b/README.md
@@ -36,10 +36,28 @@
     ]
   ```
 
+  or with per-app config:
+
+  ```elixir
+  config :my_app, Ueberauth,
+    providers: [
+      auth0: {Ueberauth.Strategy.Auth0, [otp_app: :my_app]}
+    ]
+  ```
+
   5. Update your provider configuration:
 
   ```elixir
   config :ueberauth, Ueberauth.Strategy.Auth0.OAuth,
+    domain: System.get_env("AUTH0_DOMAIN"),
+    client_id: System.get_env("AUTH0_CLIENT_ID"),
+    client_secret: System.get_env("AUTH0_CLIENT_SECRET")
+  ```
+
+  or with per-app config:
+
+  ```elixir
+  config :my_app, Ueberauth.Strategy.Auth0.OAuth,
     domain: System.get_env("AUTH0_DOMAIN"),
     client_id: System.get_env("AUTH0_CLIENT_ID"),
     client_secret: System.get_env("AUTH0_CLIENT_SECRET")
@@ -51,6 +69,17 @@
   defmodule MyApp.AuthController do
     use MyApp.Web, :controller
     plug Ueberauth
+    ...
+  end
+  ```
+
+  or with per-app config:
+
+  ```elixir
+  defmodule MyApp.AuthController do
+    use MyApp.Web, :controller
+    plug Ueberauth, otp_app: :my_app
+
     ...
   end
   ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule UeberauthAuth0.Mixfile do
   use Mix.Project
 
-  @version "0.3.1"
+  @version "0.4.0"
 
   def project do
     [


### PR DESCRIPTION
Why:

* For devs to know how to use per-app config and to include per-app
config changes to changelog.