### PR TITLE
Feature/support callback with token

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -89,7 +89,12 @@ defmodule Ueberauth.Strategy.Auth0 do
       |> apply(:client, [])
       |> Map.put(:token, token)
 
-    fetch_user(conn, client)
+    try do
+      fetch_user(conn, client)
+    rescue
+      _error ->
+        set_errors!(conn, [error("OAuth2", "Invalid token")])
+    end
   end
 
   @doc false

--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -75,22 +75,13 @@ defmodule Ueberauth.Strategy.Auth0 do
 
   def handle_callback!(
         %Conn{
-          params: %{
-            "access_token" => access_token,
-            "expires_in" => expires_at,
-            "id_token" => id_token,
-            "token_type" => token_type
-          }
+          params:
+            %{
+              "access_token" => _access_token
+            } = params
         } = conn
       ) do
-    token = %OAuth2.AccessToken{
-      access_token: access_token,
-      expires_at: expires_at,
-      other_params: %{"id_token" => id_token},
-      refresh_token: nil,
-      token_type: token_type
-    }
-
+    token = OAuth2.AccessToken.new(params)
     module = option(conn, :oauth2_module)
 
     client =


### PR DESCRIPTION
The original authentication flow only supports code as the callback parameter. It then makes a request to auth0 tenant passing code together with client_id and client_secret to get to access token and related parameters.

I'm proposing a way to directly pass access token and related as parameters on the callback function.

**Why that?**
It's not possible to integrate cypress tests with the current authentication flow because cypress doesn't allow redirects (read https://docs.cypress.io/guides/guides/web-security.html#One-Superdomain-per-Test), so we can't programmatically fill the auth0 form and click submit using cypress. Read about those issues on the following threads:
https://github.com/cypress-io/cypress/issues/1344
https://github.com/cypress-io/cypress/issues/1342#issuecomment-366747803

And it's not possible (at least I don't know how) to get code through a JS request, it needs to be through auth0 form.

So, auth0 wrote a blog post about that:
https://auth0.com/blog/end-to-end-testing-with-cypress-and-auth0/

This guide states that we need to enable password grant type so we can get the token through that (not for production - it states we should use a dev/test tenant and a production tenant without that option enabled). 

But, we also couldn't use that idea in our phoenix app, because we are using this library, and it doesn't allow callback directly with an access token and related parameters. The idea is to make our app capable of handling a get request to callbackUrl
```javascript
const callbackUrl = `http://localhost:4001/auth/auth0/callback?access_token=${access_token}&scope=openid&id_token=${id_token}&expires_in=${expires_in}&token_type=Bearer&state=${auth0State.state}`;
```

I'm not sure if there is any security problem using this approach as we are still calling userinfo using access token. 

I could not find any existing method to validate the token parameters on OAUTH2 and passing invalid tokens made server crash (Jason decode error) so I added a try/rescue as we don't control other libraries, probably this is not the best approach.

