### PR TITLE
refactor(extra): change the extra structure

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -210,11 +210,13 @@ defmodule Ueberauth.Strategy.Auth0 do
 
   @doc """
   Populates the extra section of the `Ueberauth.Auth` struct with auth0's
-  additional information from the `/userinfo` user profile.
+  additional information from the `/userinfo` user profile and includes the
+  token recieved from Auth0 callback.
   """
   def extra(conn) do
     %Extra{
       raw_info: %{
+        token: conn.private.auth0_token,
         user: conn.private.auth0_user
       }
     }

--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -213,24 +213,9 @@ defmodule Ueberauth.Strategy.Auth0 do
   additional information from the `/userinfo` user profile.
   """
   def extra(conn) do
-    user = conn.private.auth0_user
-
     %Extra{
       raw_info: %{
-        middle_name: user["middle_name"],
-        preferred_username: user["preferred_username"],
-        email_verified: user["email_verified"],
-        gender: user["gender"],
-        zoneinfo: user["zoneinfo"],
-        locale: user["locale"],
-        phone_number_verified: user["phone_number_verified"],
-        address: user["address"],
-        updated_at: user["updated_at"],
-        # The app_metadata and user_metadata are not returned by default
-        # but you can still add them using "rules" in auth0 so we're keeping
-        # this here for convenience
-        app_metadata: Map.get(user, "app_metadata", %{}),
-        user_metadata: Map.get(user, "user_metadata", %{})
+        user: conn.private.auth0_user
       }
     }
   end

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -222,6 +222,13 @@ defmodule Ueberauth.Strategy.Auth0Test do
 
     assert extra(conn) == %Extra{
              raw_info: %{
+               token: %OAuth2.AccessToken{
+                 access_token: "eyJz93alolk4laUWw",
+                 expires_at: 1_592_551_369,
+                 other_params: %{"id_token" => "eyJ0XAipop4faeEoQ"},
+                 refresh_token: "GEbRxBNkitedjnXbL",
+                 token_type: "Bearer"
+               },
                user: %{
                  "address" => %{"country" => "us"},
                  "birthdate" => "1972-03-31",

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -222,17 +222,28 @@ defmodule Ueberauth.Strategy.Auth0Test do
 
     assert extra(conn) == %Extra{
              raw_info: %{
-               address: %{"country" => "us"},
-               app_metadata: %{},
-               email_verified: true,
-               gender: "female",
-               locale: "en-US",
-               middle_name: "Josephine",
-               phone_number_verified: false,
-               preferred_username: "j.doe",
-               updated_at: "1556845729",
-               user_metadata: %{},
-               zoneinfo: "America/Los_Angeles"
+               user: %{
+                 "address" => %{"country" => "us"},
+                 "birthdate" => "1972-03-31",
+                 "email" => "janedoe@example.com",
+                 "email_verified" => true,
+                 "family_name" => "Doe",
+                 "gender" => "female",
+                 "given_name" => "Jane",
+                 "locale" => "en-US",
+                 "middle_name" => "Josephine",
+                 "name" => "Jane Josephine Doe",
+                 "nickname" => "JJ",
+                 "phone_number" => "+1 (111) 222-3434",
+                 "phone_number_verified" => false,
+                 "picture" => "http://example.com/janedoe/me.jpg",
+                 "preferred_username" => "j.doe",
+                 "profile" => "http://example.com/janedoe",
+                 "sub" => "auth0|lyy5v452u345tbn943qf",
+                 "updated_at" => "1556845729",
+                 "website" => "http://example.com",
+                 "zoneinfo" => "America/Los_Angeles"
+               }
              }
            }
   end


### PR DESCRIPTION
Looking at the changes introduced in [Adds extra field containing some profile metadata](https://github.com/achedeuzot/ueberauth_auth0/commit/ffd94e7df47fa0ceff7f33fe01a5ba6bba3045b4) feature, we only have a subset of the user being passed on in the extra field.
This PR proposes changes to the way we handle the Extra field.

**Reason for change**
While requesting information about the user in the request phase, the information returned from auth0 varies based on how the auth0 tenant is configured and the rules you have on auth0. In my case, it includes both standard and non-standard claims.

For clarity purposes, here is as an example payload of the `conn.private.auth0_user` from the request map. Notice the extra fields like `firstAuth0Login`, `identities`,  `last_password_reset` etc

```
 %{
  "app_metadata" => %{},
  "clientID" => "cUzGVpCnRAWy1UKf6ls8m8e89645678",
  "created_at" => "2018-09-20T03:36:13.236Z",
  "email" => "johnDoe@companyX.com",
  "email_verified" => true,
  "family_name" => "Doe",
  "firstAuth0Login" => false,
  "given_name" => "John",
  "https://home.companyX.com/loginProvider" => "auth0",
  "https://companyX.com/first_name" => "John",
  "https://companyX.com/lang" => "en",
  "https://companyX.com/last_name" => "Doe",
  "identities" => [
    %{
      "connection" => "Username-Password-Authentication",
      "isSocial" => false,
      "provider" => "auth0",
      "user_id" => "100145523"
    }
  ],
  "last_password_reset" => "2020-01-29T04:59:09.613Z",
  "loginProvider" => "auth0",
  "name" => "John Doe",
  "nickname" => "Doe",
  "picture" => "https://picsum.photos/id/237/250/250",
  "sub" => "auth0|100145523",
  "updated_at" => "2020-08-12T08:50:15.537Z",
  "user_id" => "auth0|100145523",
  "user_metadata" => %{
    "city" => "Kuala Lumpur",
    "country" => "MY",
    "date_of_birth" => "1940-03-18",
    "discoverable" => "false",
    "email" => "johnDoe@companyX.com",
    "event_registrations" => %{"event_registrations" => [""]},
    "first_login" => "2018-09-20T03:54:01.644Z",
    "first_name" => "John",
    "geoip" => %{
      "city_name" => "Kuala Lumpur",
      "continent_code" => "AS",
      "country_code" => "MY",
      "country_code3" => "MYS",
      "country_name" => "Malaysia",
      "latitude" => 3.1419,
      "longitude" => 101.6934,
      "time_zone" => "Asia/Kuala_Lumpur"
    },
    "industry" => "Information Technology and Services",
    "lang" => "en",
    "last_name" => "Doe",
    "location" => "Kuala Lumpur",
    "meta_tags" => ["terms_and_conditions_agreed"],
    "profession" => "Software Engineer",
    "profile_photo_url" => "https://picsum.photos/id/237/250/250",
    "tags" => [],
    "timezone" => "Etc/UTC",
    "timezone_identifier" => "Etc/UTC",
    "title" => "",
    "uid" => "auth0|100145523"
  }
}
```
Instead of handling the request info one by one, I propose we add in the whole raw data. That way values like `firstAuth0Login` and any other claim not in the info can be accessible. This will pass on the responsibility of renaming and setting default values to whoever requires the extra information and that will make it more open to varying use-cases.
The implementation borrows from other Ueberauth strategies. See the references listed below.

@achedeuzot let me know what you think.

### References
1. [https://github.com/achedeuzot/ueberauth_auth0/blob/master/lib/ueberauth/strategy/auth0.ex](https://github.com/achedeuzot/ueberauth_auth0/blob/master/lib/ueberauth/strategy/auth0.ex)
2. [https://github.com/ueberauth/ueberauth_github/blob/master/lib/ueberauth/strategy/github.ex](https://github.com/ueberauth/ueberauth_github/blob/master/lib/ueberauth/strategy/github.ex)
3. [https://github.com/ueberauth/ueberauth_facebook/blob/master/lib/ueberauth/strategy/facebook.ex](https://github.com/ueberauth/ueberauth_facebook/blob/master/lib/ueberauth/strategy/facebook.ex)


 