### PR TITLE
Support organization parameter in logins

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -70,6 +70,7 @@ defmodule Ueberauth.Strategy.Auth0 do
     default_prompt: "",
     default_screen_hint: "",
     default_login_hint: "",
+    default_organization: "",
     allowed_request_params: [
       :scope,
       :state,
@@ -77,7 +78,8 @@ defmodule Ueberauth.Strategy.Auth0 do
       :connection,
       :prompt,
       :screen_hint,
-      :login_hint
+      :login_hint,
+      :organization
     ],
     oauth2_module: Ueberauth.Strategy.Auth0.OAuth
 
@@ -102,6 +104,7 @@ defmodule Ueberauth.Strategy.Auth0 do
       |> maybe_replace_param(conn, "prompt", :default_prompt)
       |> maybe_replace_param(conn, "screen_hint", :default_screen_hint)
       |> maybe_replace_param(conn, "login_hint", :default_login_hint)
+      |> maybe_replace_param(conn, "organization", :default_organization)
       |> Map.put("state", conn.private[:ueberauth_state_param])
       |> Enum.filter(fn {k, _} -> Enum.member?(allowed_params, k) end)
       # Remove empty params

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -69,7 +69,8 @@ defmodule Ueberauth.Strategy.Auth0Test do
       |> conn(
         "/auth/auth0?scope=profile%20address%20phone&audience=https%3A%2F%2Fexample-app.auth0.com%2Fmfa%2F" <>
           "&connection=facebook&unknown_param=should_be_ignored" <>
-          "&prompt=login&screen_hint=signup&login_hint=user%40example.com"
+          "&prompt=login&screen_hint=signup&login_hint=user%40example.com" <>
+          "&organization=org_abc123"
       )
       |> SpecRouter.call(@router)
 
@@ -84,6 +85,7 @@ defmodule Ueberauth.Strategy.Auth0Test do
     assert conn.resp_body =~ ~s|response_type=code|
     assert conn.resp_body =~ ~s|scope=profile+address+phone|
     assert conn.resp_body =~ ~s|state=#{conn.private[:ueberauth_state_param]}|
+    assert conn.resp_body =~ ~s|organization=org_abc123|
   end
 
   test "default callback phase" do


### PR DESCRIPTION
To authenticate a user through an Auth0 organization, the `organization` parameter is required to be set when calling the `/authorize` endpoint.

https://auth0.com/docs/organizations/using-tokens#authenticate-users-through-an-organization