### PR TITLE
Pass organization_name and invite parameters during the redirect

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -71,6 +71,8 @@ defmodule Ueberauth.Strategy.Auth0 do
     default_screen_hint: "",
     default_login_hint: "",
     default_organization: "",
+    default_organization_name: "",
+    default_invitation: "",
     allowed_request_params: [
       :scope,
       :state,
@@ -79,7 +81,9 @@ defmodule Ueberauth.Strategy.Auth0 do
       :prompt,
       :screen_hint,
       :login_hint,
-      :organization
+      :organization,
+      :organization_name,
+      :invitation
     ],
     oauth2_module: Ueberauth.Strategy.Auth0.OAuth
 
@@ -105,6 +109,8 @@ defmodule Ueberauth.Strategy.Auth0 do
       |> maybe_replace_param(conn, "screen_hint", :default_screen_hint)
       |> maybe_replace_param(conn, "login_hint", :default_login_hint)
       |> maybe_replace_param(conn, "organization", :default_organization)
+      |> maybe_replace_param(conn, "organization_name", :default_organization_name)
+      |> maybe_replace_param(conn, "invitation", :default_invitation)
       |> Map.put("state", conn.private[:ueberauth_state_param])
       |> Enum.filter(fn {k, _} -> Enum.member?(allowed_params, k) end)
       # Remove empty params

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -70,7 +70,9 @@ defmodule Ueberauth.Strategy.Auth0Test do
         "/auth/auth0?scope=profile%20address%20phone&audience=https%3A%2F%2Fexample-app.auth0.com%2Fmfa%2F" <>
           "&connection=facebook&unknown_param=should_be_ignored" <>
           "&prompt=login&screen_hint=signup&login_hint=user%40example.com" <>
-          "&organization=org_abc123"
+          "&organization=org_abc123" <>
+          "&organization_name=Org+ABC" <>
+          "&invitation=b8galwfFB8W2UzSQhNttjhI4nyPwdpWT"
       )
       |> SpecRouter.call(@router)
 
@@ -86,6 +88,8 @@ defmodule Ueberauth.Strategy.Auth0Test do
     assert conn.resp_body =~ ~s|scope=profile+address+phone|
     assert conn.resp_body =~ ~s|state=#{conn.private[:ueberauth_state_param]}|
     assert conn.resp_body =~ ~s|organization=org_abc123|
+    assert conn.resp_body =~ ~s|organization_name=Org+ABC|
+    assert conn.resp_body =~ ~s|invitation=b8galwfFB8W2UzSQhNttjhI4nyPwdpWT|
   end
 
   test "default callback phase" do


### PR DESCRIPTION
As described in #185, the invitation parameter needs to be passed to the Auth0 redirect for organization invites. 

I also added the organization_name, which is an optional parameter.