### PR TITLE
feat(invitation): Adds invitation param for invitation only user logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Support for `organization` and `invitation` query parameters
+- Bumped dependencies
 
 ## v2.0.0 - 2021-08-14
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@
 
 For an example implementation see the [Überauth Example](https://github.com/ueberauth/ueberauth_example) application.
 
+## Learn about OAuth2
+[OAuth2 explained with cute shapes](https://engineering.backmarket.com/oauth2-explained-with-cute-shapes-7eae51f20d38)
 
 ## Copyright and License
 

--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -71,6 +71,8 @@ defmodule Ueberauth.Strategy.Auth0 do
     default_screen_hint: "",
     default_login_hint: "",
     default_organization: "",
+    # See https://auth0.com/docs/manage-users/organizations/configure-organizations/invite-members#specify-route-behavior
+    default_invitation: "",
     allowed_request_params: [
       :scope,
       :state,
@@ -79,7 +81,8 @@ defmodule Ueberauth.Strategy.Auth0 do
       :prompt,
       :screen_hint,
       :login_hint,
-      :organization
+      :organization,
+      :invitation
     ],
     oauth2_module: Ueberauth.Strategy.Auth0.OAuth
 
@@ -105,6 +108,7 @@ defmodule Ueberauth.Strategy.Auth0 do
       |> maybe_replace_param(conn, "screen_hint", :default_screen_hint)
       |> maybe_replace_param(conn, "login_hint", :default_login_hint)
       |> maybe_replace_param(conn, "organization", :default_organization)
+      |> maybe_replace_param(conn, "invitation", :default_invitation)
       |> Map.put("state", conn.private[:ueberauth_state_param])
       |> Enum.filter(fn {k, _} -> Enum.member?(allowed_params, k) end)
       # Remove empty params

--- a/test/strategy/auth0_test.exs
+++ b/test/strategy/auth0_test.exs
@@ -70,7 +70,7 @@ defmodule Ueberauth.Strategy.Auth0Test do
         "/auth/auth0?scope=profile%20address%20phone&audience=https%3A%2F%2Fexample-app.auth0.com%2Fmfa%2F" <>
           "&connection=facebook&unknown_param=should_be_ignored" <>
           "&prompt=login&screen_hint=signup&login_hint=user%40example.com" <>
-          "&organization=org_abc123"
+          "&organization=org_abc123&invitation=INVITE2022"
       )
       |> SpecRouter.call(@router)
 
@@ -86,6 +86,7 @@ defmodule Ueberauth.Strategy.Auth0Test do
     assert conn.resp_body =~ ~s|scope=profile+address+phone|
     assert conn.resp_body =~ ~s|state=#{conn.private[:ueberauth_state_param]}|
     assert conn.resp_body =~ ~s|organization=org_abc123|
+    assert conn.resp_body =~ ~s|invitation=INVITE2022|
   end
 
   test "default callback phase" do


### PR DESCRIPTION
This adds the `invitation` query parameter.

It closes #186 and closes #202 for now.